### PR TITLE
better tabindex practices

### DIFF
--- a/_includes/contact-form.html
+++ b/_includes/contact-form.html
@@ -2,7 +2,9 @@
 <a href="#"
   class="btn btn-round text-white bg-purple hover-white mx-auto"
   on="tap:contact-lightbox"
-  role="button">
+  role="button"
+  tabindex="0"
+>
   Contact us &nbsp;<i class="far fa-envelope"></i>
 </a>
 
@@ -12,7 +14,7 @@
   layout="nodisplay"
   scrollable
   on="tap:contact-lightbox.close"
-  tabindex="20"
+  tabindex="0"
   role="dialog"
 >
   <div class="container px-5 pt-5 text-white">
@@ -27,8 +29,9 @@
   <div
     class="form-container"
     on="tap:contact-lightbox.open"
+    tabindex="-1"
     role="form"
-    tabindex="19">
+  >
     <input name="lifecyclestage" type="hidden" value="lead">
     <input name="hs_lead_status" type="hidden" value="NEW">
     <input name="page_name" type="hidden" value="{{page.title}}">
@@ -53,7 +56,6 @@
             data-msg="Please enter your first name."
             data-error-class="u-has-error"
             data-success-class="u-has-success"
-            tabindex="1"
           />
         </div>
       </div>
@@ -77,7 +79,6 @@
             data-msg="Please enter your last name."
             data-error-class="u-has-error"
             data-success-class="u-has-success"
-            tabindex="2"
           />
         </div>
       </div>
@@ -101,7 +102,6 @@
             data-msg="Please enter a valid email address."
             data-error-class="u-has-error"
             data-success-class="u-has-success"
-            tabindex="3"
           />
         </div>
       </div>
@@ -125,7 +125,6 @@
             data-msg="Please enter your phone number."
             data-error-class="u-has-error"
             data-success-class="u-has-success"
-            tabindex="4"
           />
         </div>
       </div>
@@ -149,7 +148,6 @@
             data-msg="Please enter a message."
             data-error-class="u-has-error"
             data-success-class="u-has-success"
-            tabindex="5"
           ></textarea>
         </div>
       </div>
@@ -161,7 +159,6 @@
         <button
           type="submit"
           class="text-white btn btn-round bg-purple hover-white"
-          tabindex="18"
         >
           Send
         </button>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,7 +5,7 @@
 {% unless page.categories contains 'landing' %}
 <amp-sidebar
   on="tap:sidebar.open"
-  tabindex="1"
+  tabindex="-1"
   role="navigation"
   id="sidebar"
   class="m-0 bg-dark d-flex d-md-none row flex-column align-items-start justify-content-start"
@@ -16,7 +16,8 @@
       class="mt-5 text-left"
       on="tap:sidebar.open"
       role="dialog"
-      tabindex="20">
+      tabindex="-1"
+    >
       {% if item.children %}
         <div class="mx-5 text-white">
           {{ item.title }}
@@ -91,8 +92,9 @@
         <button
           class="display-5 text-white btn btn-link d-flex justify-content-end d-md-none"
           on="tap:sidebar.open"
-          tabindex="2"
-          role="button">
+          tabindex="0"
+          role="button"
+        >
           <i class="fas fa-bars"></i>
         </button>
         <!-- End Responsive Toggle Button -->

--- a/_includes/observer-and-header-animation.html
+++ b/_includes/observer-and-header-animation.html
@@ -1,7 +1,9 @@
 <amp-position-observer
   on="scroll:fill-header-background.seekTo(percent=event.percent)"
   intersection-ratios="0"
-  layout="nodisplay">
+  layout="nodisplay"
+  tabindex="-1"
+>
 </amp-position-observer>
 
 <amp-animation id="fill-header-background" layout="nodisplay">

--- a/_includes/profiles-page.html
+++ b/_includes/profiles-page.html
@@ -21,6 +21,7 @@
                 selectedName:'{{profile.name}}',
                 selectedTitle:'{{profile.title}}'
               }),bio-section.scrollTo(duration=200)"
+              tabindex="0"
             ></amp-img>
             <!-- htmllint preset="$previous" -->
               <p class="p-1 text-center">

--- a/_includes/referral-question.html
+++ b/_includes/referral-question.html
@@ -4,7 +4,7 @@
     How did you hear about us? <span class="text-danger">*</span>
   </label>
 
-  <select id="referral" name="how_did_you_hear_about_us" class="form-control" tabindex="6">
+  <select id="referral" name="how_did_you_hear_about_us" class="form-control">
 
     <option value="" disabled selected>
       Select your answer

--- a/index.html
+++ b/index.html
@@ -83,7 +83,8 @@ form_guid: c34e4ad8-2fe9-49d1-aaba-c8d77f294986
           class="btn btn-outline-light btn-round mr-2 px-2 d-sm-none"
           on="tap:call-us"
           role="button"
-          tabindex="1">
+          tabindex="0"
+        >
           Get More Info
         </button>
         <amp-lightbox
@@ -92,26 +93,25 @@ form_guid: c34e4ad8-2fe9-49d1-aaba-c8d77f294986
           layout="nodisplay"
           scrollable
           on="tap:call-us.close"
+          tabindex="0"
           role="dialog"
-          tabindex="20">
+        >
           <div class="mt-11 pt-5 d-flex mx-auto flex-column align-items-center">
             <!-- htmllint preset="none" -->
-            <a
-              class="my-5 btn btn-light btn-round mr-2 d-sm-none"
+            <a class="my-5 btn btn-light btn-round mr-2 d-sm-none"
               href="https://app.acuityscheduling.com/schedule.php?owner=11951420&appointmentType=1406673"
               target="_blank"
               rel="noopener"
-              tabindex="1">
+            >
               Schedule a Q&amp;A
             </a>
             <!-- htmllint preset="$previous" -->
             <h4 class="text-white display-7 border-top border-bottom">
               OR
             </h4>
-            <a
-              class="my-5 btn btn-light btn-round mr-2 d-sm-none"
+            <a class="my-5 btn btn-light btn-round mr-2 d-sm-none"
               href="tel:5128278498"
-              tabindex="2">
+            >
               Call Us Now!
             </a>
           </div>


### PR DESCRIPTION
Google warned us in the past about ensuring all elements with an 'on' attribute also have a 'tabindex' attribute; at the time I was not aware of how to properly declare tabindex without disrupting the natural order. With this update everything should tab in the expected order and appropriate items should be skipped