### PR TITLE
Add back tutoring

### DIFF
--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -83,8 +83,8 @@ lubbock_footer:
   title: Become an Instructor
   url: "/instructor-apply"
 - weight: 2
-  title: Upcoming Events
-  url: "/events"
+  title: Tutoring
+  url: "/tutoring"
 - weight: 1
   title: Hack Overflow
   url: https://austincodingacademy.com/forum
@@ -110,8 +110,8 @@ austin_footer:
   title: Become an Instructor
   url: "/instructor-apply"
 - weight: 3
-  title: Upcoming Events
-  url: "/events"
+  title: Tutoring
+  url: "/tutoring"
 - weight: 2
   title: Hack Overflow
   url: https://austincodingacademy.com/forum


### PR DESCRIPTION
Events in the footer was replaced by /tutoring since events is already in the header 'about us' dropdown. 