### PR TITLE
csharp and web dev mobile fixes

### DIFF
--- a/_includes/elective-page.html
+++ b/_includes/elective-page.html
@@ -1,7 +1,7 @@
 <!-- htmllint preset="none" -->
 <div id="hero-{{ page.hero }}" class="hero mt-5 mt-sm-0 py-5 py-md-11">
   <!-- htmllint preset="$previous" -->
-    <h1 class="mt-10 mb-5 mb-md-10 text-white font-family-alt font-weight-bold display-4 text-center">
+    <h1 class="mt-10 mb-5 mb-md-10 text-white font-family-alt font-weight-bold display-55 display-sm-5 text-center">
       {{ page.hero_title }}
     </h1>
     <p class="text-white text-center mx-auto px-2 mw-600">

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -200,6 +200,12 @@ p {
   line-height: 1.2;
 }
 
+.display-55 {
+  font-size: 2.5rem;
+  font-weight: 300;
+  line-height: 1.2;
+}
+
 .display-6 {
   font-size: 2rem;
   font-weight: 300;

--- a/web-development.html
+++ b/web-development.html
@@ -196,7 +196,7 @@ lubbock:
 <!-- htmllint preset="none" -->
 <div id="hero-{{ city.hero }}" class="hero py-5 py-md-11">
 <!-- htmllint preset="$previous" -->
-  <h1 class="mt-10 mb-5 mb-md-10 text-white font-family-alt font-weight-bold display-4 text-center">
+  <h1 class="mt-10 mb-5 mb-md-10 text-white font-family-alt font-weight-bold display-55 display-sm-5 text-center">
     Full Stack Web Development
   </h1>
   <p class="text-white text-center mx-auto px-2 mw-600">


### PR DESCRIPTION
noticed white space on right for /web-dev and /csharp on my phone.  shrinking the hero text a bit in mobile fixed it. it was the long words like 'programming'. 